### PR TITLE
[TASK] Make compatible with Apache Solr 7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.typo3.solr</groupId>
     <artifactId>solr-typo3-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
     <name>Solr TYPO3 Plugin</name>
     <description>A plugin for Solr to implement TYPO3 support functionality.</description>
@@ -59,7 +59,7 @@
     </organization>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <solr.version>6.3.0</solr.version>
+        <solr.version>7.4.0</solr.version>
         <timestamp>${maven.build.timestamp}</timestamp>
     </properties>
     <build>
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/org/typo3/solr/search/AccessFilterQParserPlugin.java
+++ b/src/main/java/org/typo3/solr/search/AccessFilterQParserPlugin.java
@@ -20,10 +20,11 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
+import com.codahale.metrics.Metric;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
-import org.apache.solr.core.SolrInfoMBean;
+import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.QParserPlugin;
@@ -34,7 +35,7 @@ import org.apache.solr.search.QParserPlugin;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-public class AccessFilterQParserPlugin extends QParserPlugin implements SolrInfoMBean {
+public class AccessFilterQParserPlugin extends QParserPlugin implements SolrInfoBean {
 
   /**
    * The name of the query parser. Used in solrconfig.xml and in queries.
@@ -54,11 +55,13 @@ public class AccessFilterQParserPlugin extends QParserPlugin implements SolrInfo
    */
   public void init(final NamedList args) {
     try {
+
       Properties p = new Properties();
       InputStream is = getClass().getResourceAsStream("plugin.properties");
       if (is != null) {
         p.load(is);
         version = p.getProperty("version");
+
       }
     } catch (Exception e) {
       System.out.println("BOOO! " + e.toString());
@@ -90,40 +93,19 @@ public class AccessFilterQParserPlugin extends QParserPlugin implements SolrInfo
 
   // SolrInfoMBean
 
-
   @Override
   public final String getName() {
     return this.getClass().getName();
   }
 
   @Override
-  public final String getVersion() {
-    return version;
-  }
-
-  @Override
   public final String getDescription() {
-    return "A filter plugin to support TYPO3 access restrictions.";
+    return "A filter plugin to support TYPO3 access restrictions. (Version: "+version+")";
   }
 
   @Override
   public final Category getCategory() {
-    return SolrInfoMBean.Category.OTHER;
-  }
-
-  @Override
-  public final String getSource() {
-    return null;
-  }
-
-  @Override
-  public final URL[] getDocs() {
-    return null;
-  }
-
-  @Override
-  public final NamedList getStatistics() {
-    return new SimpleOrderedMap();
+    return SolrInfoBean.Category.OTHER;
   }
 
 }

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserPluginTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserPluginTest.java
@@ -79,9 +79,9 @@ public class AccessFilterQParserPluginTest extends RestTestBase {
         if (objectInfo instanceof LinkedHashMap) {
             @SuppressWarnings("unchecked")
             LinkedHashMap<String, String> pluginInfo = (LinkedHashMap<String, String>) objectInfo;
-            String version = pluginInfo.get("version");
-
-            assertTrue(version.startsWith("2."));
+            String description = pluginInfo.get("description");
+            String version = description.substring(description.indexOf("Version: ") + 9, description.indexOf(")"));
+            assertTrue(version.startsWith("3."));
         } else {
             fail();
         }

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserSingleValueTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserSingleValueTest.java
@@ -36,6 +36,7 @@ public class AccessFilterQParserSingleValueTest extends SolrTestCaseJ4 {
 	public void before() throws Exception {
 		initCore("solrconfig.xml", "schema.xml");
 		createIndex();
+
 	}
 
 

--- a/src/test/resources/solr/collection1/conf/solrconfig.xml
+++ b/src/test/resources/solr/collection1/conf/solrconfig.xml
@@ -12,11 +12,6 @@
 
 	<abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
 	<indexConfig>
-		<!-- this sys property is not set by SolrTestCaseJ4 because we ideally want to use
-               the RandomMergePolicy in all tests - but some tests expect very specific
-               Merge behavior, so those tests can set it as needed.
-		-->
-		<mergePolicy class="${solr.tests.mergePolicy:org.apache.solr.util.RandomMergePolicy}" />
 
 		<useCompoundFile>${useCompoundFile:false}</useCompoundFile>
 


### PR DESCRIPTION
Several things where needed to make the plugin runable with Apache Solr 7.4

* Adapt api changes in SortedSetDocValues and SortedDocValues to use the advance method
* Change to output the version in the description since the definition of custom nodes is not possible anymore
* Use a never version of the maven shade plugin

Fixes: #14