### PR TITLE
[TASK] Apache Solr 9.2 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.typo3.solr</groupId>
     <artifactId>solr-typo3-plugin</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
     <packaging>jar</packaging>
     <name>Solr TYPO3 Plugin</name>
     <description>A plugin for Solr to implement TYPO3 support functionality.</description>
@@ -56,7 +56,7 @@
     </organization>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <solr.version>8.8.2</solr.version>
+        <solr.version>9.2.0</solr.version>
         <timestamp>${maven.build.timestamp}</timestamp>
         <java.compat.version>11</java.compat.version>
     </properties>
@@ -65,21 +65,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>org.apache.maven.surefire</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -118,17 +118,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.14</version>
+                <version>3.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.20</version>
                 <configuration>
                     <linkXRef>true</linkXRef>
                     <sourceEncoding>utf-8</sourceEncoding>
@@ -144,17 +144,17 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.5.0</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs/spotbugs-maven-plugin</artifactId>
+                <version>4.7</version>
             </plugin>
         </plugins>
     </reporting>

--- a/src/main/java/org/typo3/solr/search/AccessFilter.java
+++ b/src/main/java/org/typo3/solr/search/AccessFilter.java
@@ -27,7 +27,6 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.solr.schema.IndexSchema;
-import org.apache.solr.search.Filter;
 import org.typo3.access.Rootline;
 import org.typo3.access.RootlineElement;
 import org.typo3.access.RootlineElementType;
@@ -100,6 +99,15 @@ public class AccessFilter extends ExtendedQueryBase implements PostFilter {
   }
 
   /**
+   * Recurse through the query tree, visiting any child queries
+   * @param visitor a QueryVisitor to be called by each query in the tree
+   */
+  @Override
+  public void visit(QueryVisitor visitor) {
+    visitor.visitLeaf(this);
+  }
+
+  /**
    * This method iterates over the documents and marks documents as accessable that are granted
    * and have the access information in a single value field.
    *
@@ -112,7 +120,7 @@ public class AccessFilter extends ExtendedQueryBase implements PostFilter {
   private boolean handleSingleValueAccessField(int doc, SortedDocValues values) throws IOException {
 
     values.advance(doc);
-    BytesRef bytes = values.binaryValue();
+    BytesRef bytes = values.lookupOrd(values.ordValue());
     String documentGroupList = bytes.utf8ToString();
 
     if (accessGranted(documentGroupList)) {
@@ -182,9 +190,9 @@ public class AccessFilter extends ExtendedQueryBase implements PostFilter {
       }
 
       /**
-       * Called for each document that need to be considered, if we do 
+       * Called for each document that need to be considered, if we do
        * not call super.collect, the document will effectively be filtered here.
-       * 
+       *
        *
        * @param doc
        * @throws IOException

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserPluginTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserPluginTest.java
@@ -81,7 +81,7 @@ public class AccessFilterQParserPluginTest extends RestTestBase {
             LinkedHashMap<String, String> pluginInfo = (LinkedHashMap<String, String>) objectInfo;
             String description = pluginInfo.get("description");
             String version = description.substring(description.indexOf("Version: ") + 9, description.indexOf(")"));
-            assertTrue(version.startsWith("5."));
+            assertTrue(version.startsWith("6."));
         } else {
             fail();
         }


### PR DESCRIPTION
To be compatible with Apache Solr 9.2 some adaptions are required:

- SortedDocValues no longer extends BinaryDocValues (LUCENE-9796) thus binaryValue() can't be used. According to the migration hints now lookupOrd(ordValue()) is used.
- AccessFilter has to implement visit(), as it's no longer implemented in base Query class
- Removed include of deprecated and unused Filter (SOLR-12336)