### PR TITLE
[TASK] Update to Apache Solr 9.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </organization>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <solr.version>9.6.0</solr.version>
+        <solr.version>9.6.1</solr.version>
         <timestamp>${maven.build.timestamp}</timestamp>
         <java.compat.version>17</java.compat.version>
     </properties>
@@ -171,6 +171,12 @@
             <artifactId>solr-test-framework</artifactId>
             <version>${solr.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>zookeeper</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
Updates to Apache Solr 9.6.1 and excludes zookeeper dependencies as unneeded and vulnerable in current version 3.9.1 that is used by Apache Solr.