### PR TITLE
[TASK] Update to Apache Solr 9.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,21 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    # Workaround for issue with actions/checkout "wrong PR commit checkout":
+    #   See:
+    #   ** https://github.com/actions/checkout/issues/299#issuecomment-677674415
+    #   ** https://github.com/actions/checkout/issues/1359#issuecomment-1631503791
+    -
+      name: Checkout current state of Pull Request
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    -
+      name: Checkout current state of Branch
+      if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+      uses: actions/checkout@v4
+    # End: Workaround for issue with actions/checkout...
 
     - name: Set up JDK 17 for x64
       uses: actions/setup-java@v4

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </organization>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <solr.version>9.6.1</solr.version>
+        <solr.version>9.8.0</solr.version>
         <timestamp>${maven.build.timestamp}</timestamp>
         <java.compat.version>17</java.compat.version>
     </properties>

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserMultiValueTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserMultiValueTest.java
@@ -33,6 +33,7 @@ public class AccessFilterQParserMultiValueTest extends SolrTestCaseJ4 {
 
     @Before
     public void before() throws Exception {
+        System.setProperty("solr.directoryFactory", "solr.MockDirectoryFactory");
         initCore("solrconfig.xml", "schema.xml");
     }
 

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserSingleValueTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserSingleValueTest.java
@@ -19,7 +19,6 @@ package org.typo3.solr.search;
 import org.apache.solr.SolrTestCaseJ4;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 
@@ -34,9 +33,9 @@ public class AccessFilterQParserSingleValueTest extends SolrTestCaseJ4 {
 
 	@Before
 	public void before() throws Exception {
+		System.setProperty("solr.directoryFactory", "solr.MockDirectoryFactory");
 		initCore("solrconfig.xml", "schema.xml");
 		createIndex();
-
 	}
 
 

--- a/src/test/java/org/typo3/solr/search/AccessFilterQParserWithRootLineTest.java
+++ b/src/test/java/org/typo3/solr/search/AccessFilterQParserWithRootLineTest.java
@@ -19,7 +19,6 @@ package org.typo3.solr.search;
 import org.apache.solr.SolrTestCaseJ4;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 
@@ -34,6 +33,7 @@ public class AccessFilterQParserWithRootLineTest extends SolrTestCaseJ4 {
 
 	@Before
 	public void before() throws Exception {
+		System.setProperty("solr.directoryFactory", "solr.MockDirectoryFactory");
 		initCore("solrconfig.xml", "schema.xml");
 		createIndex();
 	}

--- a/src/test/resources/solr/collection1/conf/solrconfig.xml
+++ b/src/test/resources/solr/collection1/conf/solrconfig.xml
@@ -5,8 +5,8 @@
 
 	<!--  The DirectoryFactory to use for indexes.
         solr.StandardDirectoryFactory, the default, is filesystem based.
-        solr.RAMDirectoryFactory is memory based and not persistent. -->
-	<directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+        solr.MockDirectoryFactory is intended for tests -->
+	<directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}"/>
 
 	<luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
 


### PR DESCRIPTION
Adjusts the following tests not using the provided solrconfig testing
file:
- AccessFilterQParserMultiValueTest
- AccessFilterQParserSingleValueTest
- AccessFilterQParserWithRootLineTest

As the lock type is not set if the solrconfig file is not used, the
directoryFactory RAMDirectoryFactory used as default by SolrTestCaseJ4
will fail as it cannot be used with the default lock type.

As the RAMDirectory is deprecated since Solr 7.6.0 we switch to the
MockDirectoryFactory which is intended to be used with tests.

This change is still compatible with Apache Solr 9.6.